### PR TITLE
Add check in tree building for case where no split exists on a variable

### DIFF
--- a/Charon/Charon/Tree.fs
+++ b/Charon/Charon/Tree.fs
@@ -68,11 +68,15 @@ module Tree =
         | Num(branch,next) ->
             let f = branch.FeatIndex
             let splits = branch.Splits |> List.toArray
-            if (i=Array.length splits)
+            if (Array.length splits > 0)
             then
-                (fst fs.[f]), sprintf ">  %.3f" (splits.[i-1])
+                if (i=Array.length splits)
+                then
+                    (fst fs.[f]), sprintf ">  %.3f" (splits.[max 0 i-1])
+                else
+                    (fst fs.[f]), sprintf "<= %.3f" (splits.[i])
             else
-                (fst fs.[f]), sprintf "<= %.3f" (splits.[i])
+                (fst fs.[f]), "INVARIABLE"
 
     let rec display (tree:Tree) (actives:int Set) (depth:int) (translator:(string*FeatureMap)*((string*FeatureMap)[]))=
         let ls,fs = translator


### PR DESCRIPTION
First of all, thanks for making this- really neat and useful!

Currently the code can produce an ArrayIndexOutOfBoundsException when building the string representation of the decision tree if no branch occurs. I believe this could reasonably be addressed by simply checking if the array of "splits" is empty before trying to access an element of the array to building the representation. That change seemed to fix the error I was previously experiencing, at least.
